### PR TITLE
feat: change airdrop into a raffle

### DIFF
--- a/contracts/genie-airdrop/src/contract.rs
+++ b/contracts/genie-airdrop/src/contract.rs
@@ -13,7 +13,6 @@ use genie::airdrop::{
 use genie::asset::{build_transfer_asset_msg, query_balance, AssetInfo};
 
 const CONTRACT_NAME: &str = "genie-airdrop";
-
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[cfg_attr(not(feature = "library"), entry_point)]

--- a/contracts/genie-airdrop/src/contract.rs
+++ b/contracts/genie-airdrop/src/contract.rs
@@ -12,7 +12,8 @@ use genie::airdrop::{
 };
 use genie::asset::{build_transfer_asset_msg, query_balance, AssetInfo};
 
-const CONTRACT_NAME: &str = "genie-raffle";
+const CONTRACT_NAME: &str = "genie-airdrop";
+
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[cfg_attr(not(feature = "library"), entry_point)]
@@ -201,8 +202,6 @@ pub fn handle_claim(
     let claim_string = String::from_utf8(claim_amounts.to_vec())?;
     let claim_amounts = claim_string
         .split(",")
-        .collect::<Vec<&str>>()
-        .iter()
         .map(|x| x.parse::<Uint128>())
         .collect::<Result<Vec<Uint128>, _>>()?;
 

--- a/packages/genie/src/airdrop.rs
+++ b/packages/genie/src/airdrop.rs
@@ -1,6 +1,6 @@
+use crate::asset::AssetInfo;
 use cosmwasm_std::{Binary, Uint128};
 use cw20::Cw20ReceiveMsg;
-use crate::asset::AssetInfo;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -19,7 +19,7 @@ pub struct InstantiateMsg {
 pub enum ExecuteMsg {
     Receive(Cw20ReceiveMsg),
     Claim {
-        claim_amounts: Vec<Uint128>,
+        claim_amounts: Binary,
         signature: Binary,
     },
     IncreaseIncentives {},


### PR DESCRIPTION
Summary

- Copy code from genie-airdrop to genie-raffle
- Change claim message from vec[uint128] to base64 string
- Allow for 0 token claims (claiming additional 0 tokens)
- Reviewed once by @jacobkwan here https://github.com/coinhall/genie-contracts/pull/16

Testing
- Edited test cases to fit raffle

Comments
- Consider changing the emit events to avoid conflict during parsing with normal airdrops