### PR TITLE
fix query_status from being stuck if there is too many claims made

### DIFF
--- a/contracts/genie-airdrop/Cargo.toml
+++ b/contracts/genie-airdrop/Cargo.toml
@@ -36,7 +36,7 @@ optimize-m1 = """docker run --rm -v "$(pwd)":/code \
 [dependencies]
 genie = { path = "../../packages/genie", default-features = false, version = "0.1.0" }
 cosmwasm-std = "1.0.0"
-cw-storage-plus = "0.13.2"
+cw-storage-plus = "1.1.0"
 cw2 = "0.13.4"
 cw-controllers = "0.13.2"
 schemars = "0.8.8"

--- a/contracts/genie-airdrop/src/contract.rs
+++ b/contracts/genie-airdrop/src/contract.rs
@@ -1,8 +1,8 @@
 use crate::crypto::is_valid_signature;
 use crate::state::{Config, State, CONFIG, STATE, USERS};
 use cosmwasm_std::{
-    attr, entry_point, from_binary, to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Order,
-    Response, StdError, StdResult, Uint128,
+    attr, entry_point, from_binary, to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response,
+    StdError, StdResult, Uint128,
 };
 use cw2::set_contract_version;
 use cw20::Cw20ReceiveMsg;
@@ -361,14 +361,12 @@ fn query_has_user_claimed(deps: Deps, user_address: String) -> StdResult<ClaimRe
 
 fn query_status(deps: Deps, env: &Env) -> StdResult<StatusResponse> {
     let config = CONFIG.load(deps.storage)?;
-    let users_count = USERS
-        .range(deps.storage, None, None, Order::Ascending)
-        .count();
+    let users_is_empty = USERS.is_empty(deps.storage);
     let state = STATE.load(deps.storage)?;
     let current_amount = state.protocol_funding;
 
     if env.block.time.seconds() >= config.from_timestamp
-        && users_count == usize::from(0u8)
+        && users_is_empty
         && current_amount < config.allocated_amount
     {
         Ok(StatusResponse {


### PR DESCRIPTION
Summary
- Upgraded cw-storage-plus to 1.1.0 to have new features
- Fix query_status to use is_empty() instead of range().count() to prevent being stuck in the case of too many claims

Testing
- Testnet