### PR TITLE
fix: add check for from_timestamp to be more than current time

### DIFF
--- a/contracts/genie-airdrop/src/contract.rs
+++ b/contracts/genie-airdrop/src/contract.rs
@@ -18,12 +18,12 @@ const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn instantiate(
     deps: DepsMut,
-    _env: Env,
+    env: Env,
     _info: MessageInfo,
     msg: InstantiateMsg,
 ) -> StdResult<Response> {
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
-    if msg.from_timestamp <= _env.block.time.seconds() {
+    if msg.from_timestamp <= env.block.time.seconds() {
         return Err(StdError::generic_err(
             "from_timestamp must be greater than current time",
         ));

--- a/contracts/genie-airdrop/src/contract.rs
+++ b/contracts/genie-airdrop/src/contract.rs
@@ -23,7 +23,7 @@ pub fn instantiate(
     msg: InstantiateMsg,
 ) -> StdResult<Response> {
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
-    if msg.from_timestamp >= _env.block.time.seconds() {
+    if msg.from_timestamp <= _env.block.time.seconds() {
         return Err(StdError::generic_err(
             "from_timestamp must be greater than current time",
         ));

--- a/contracts/genie-airdrop/src/contract.rs
+++ b/contracts/genie-airdrop/src/contract.rs
@@ -23,6 +23,11 @@ pub fn instantiate(
     msg: InstantiateMsg,
 ) -> StdResult<Response> {
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+    if msg.from_timestamp >= _env.block.time.seconds() {
+        return Err(StdError::generic_err(
+            "from_timestamp must be greater than current time",
+        ));
+    }
     if msg.to_timestamp <= msg.from_timestamp {
         return Err(StdError::generic_err(
             "to_timestamp must be greater than from_timestamp",


### PR DESCRIPTION
Summary
 - add a from_timestamp check to prevent invalid campaigns
 - campaigns are unusable if they are already past the start time and nothing is deposited inside