### PR TITLE
feat: limit number of missions in airdrop-factory to 5

### DIFF
--- a/contracts/genie-airdrop-factory/src/contract.rs
+++ b/contracts/genie-airdrop-factory/src/contract.rs
@@ -107,6 +107,10 @@ pub fn execute_create_airdrop(
 ) -> StdResult<Response> {
     let config: Config = CONFIG.load(deps.storage)?;
 
+    if allocated_amounts.len() > 5 {
+        return Err(StdError::generic_err("too many allocation amounts"));
+    }
+
     Ok(Response::new()
         .add_attributes(vec![
             attr("action", "genie_create_campaign"),


### PR DESCRIPTION
Summary
- limit number of missions to 5