### PR TITLE
refactor claim function to base64 encoded 

### DIFF
--- a/contracts/genie-airdrop/src/contract.rs
+++ b/contracts/genie-airdrop/src/contract.rs
@@ -343,15 +343,11 @@ pub fn handle_transfer_unclaimed_tokens(
     // without using the `increase_incentives` execute msg.
     let amount = query_balance(&deps.as_ref().querier, &env.contract.address, &config.asset)?;
     let mut state = STATE.load(deps.storage)?;
-    state.protocol_funding = Uint128::zero();
-    // Do not reset unclaimed_amounts if campaign has not started
-    if status != Status::NotStarted {
-        state.unclaimed_amounts = state
-            .unclaimed_amounts
-            .iter()
-            .map(|_| Uint128::zero())
-            .collect();
-    }
+    state.protocol_funding = state
+        .protocol_funding
+        .checked_sub(amount)
+        .unwrap_or(Uint128::zero());
+
     STATE.save(deps.storage, &state)?;
 
     // Transfer assets to recipient

--- a/contracts/genie-airdrop/src/contract.rs
+++ b/contracts/genie-airdrop/src/contract.rs
@@ -370,12 +370,12 @@ pub fn handle_transfer_unclaimed_tokens(
 fn query_state(deps: Deps, env: Env) -> StdResult<StateResponse> {
     let state = STATE.load(deps.storage)?;
     let asset = CONFIG.load(deps.storage)?.asset;
-    let current_amount = query_balance(&deps.querier, &env.contract.address, &asset)?;
+    let current_balance = query_balance(&deps.querier, &env.contract.address, &asset)?;
 
     Ok(StateResponse {
         unclaimed_amounts: state.unclaimed_amounts,
         protocol_funding: state.protocol_funding,
-        current_amount,
+        current_balance,
     })
 }
 

--- a/contracts/genie-airdrop/src/state.rs
+++ b/contracts/genie-airdrop/src/state.rs
@@ -35,7 +35,7 @@ pub struct State {
 pub struct UserInfo {
     /// Assets claimed, per mission, by this account
     pub claimed_amounts: Vec<Uint128>,
-    /// If applicable to this campaign, lootboxes claimed, per mission, by this account 
+    /// If applicable to this campaign, lootboxes claimed, per mission, by this account
     pub claimed_lootbox: Option<Vec<Uint128>>,
 }
 

--- a/packages/genie/src/airdrop.rs
+++ b/packages/genie/src/airdrop.rs
@@ -83,7 +83,7 @@ pub struct StateResponse {
     /// Total funds protocol has sent and removed to this contract via `increase_incentives` and `transfer_unclaimed_tokens`
     pub protocol_funding: Uint128,
     /// Actual amount of tokens in this contract
-    pub current_amount: Uint128,
+    pub current_balance: Uint128,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/packages/genie/src/airdrop.rs
+++ b/packages/genie/src/airdrop.rs
@@ -77,6 +77,16 @@ pub struct StatusResponse {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct StateResponse {
+    /// Unclaimed amount, per mission, currently in this contract
+    pub unclaimed_amounts: Vec<Uint128>,
+    /// Total funds protocol has sent and removed to this contract via `increase_incentives` and `transfer_unclaimed_tokens`
+    pub protocol_funding: Uint128,
+    /// Actual amount of tokens in this contract
+    pub current_amount: Uint128,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct LootboxInfo {
     pub claimed_lootbox: Binary,
 }

--- a/packages/genie/src/airdrop.rs
+++ b/packages/genie/src/airdrop.rs
@@ -18,22 +18,23 @@ pub struct InstantiateMsg {
 #[serde(rename_all = "snake_case")]
 pub enum ExecuteMsg {
     Receive(Cw20ReceiveMsg),
-    Claim {
-        claim_amounts: Binary,
-        signature: Binary,
-        lootbox_info: Option<LootboxInfo>,
-    },
+    Claim { payload: Binary },
     IncreaseIncentives {},
-    TransferUnclaimedTokens {
-        recipient: String,
-        amount: Uint128,
-    },
+    TransferUnclaimedTokens { recipient: String },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum Cw20HookMsg {
     IncreaseIncentives {},
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct ClaimPayload {
+    pub claim_amounts: Vec<Uint128>,
+    pub signature: Binary,
+    pub lootbox_info: Option<Vec<Uint128>>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]


### PR DESCRIPTION
Summary
- refactor claim function to base64 encoded 
- refactor transfer unclaimed to not need amount (transfer all)
- set unclaimed_amount to 0 when executing transfer_unclaimed if campaign is past start date

Testing
- tested on testnet